### PR TITLE
docs: define framework extraction roadmap and branch baseline

### DIFF
--- a/Docs/0023-ARCH-framework-extraction-opportunities.md
+++ b/Docs/0023-ARCH-framework-extraction-opportunities.md
@@ -1,0 +1,169 @@
+---
+id: 0023
+priority: P2
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0008, #0017, #0018, #0022]
+status: ACTIVE
+---
+
+# TinyChaton 可框架化实现审查（按“对标可行性”重排）
+
+## 审查范围
+
+1. 仅讨论“可抽象为框架”的实现机会。
+2. 不做 BUG、回归、性能结论。
+3. 本文将实现分为三类：
+- A 类：可直接对标著名框架。
+- B 类：只能概念对标，不应一一映射。
+- C 类：不宜对标，应保持领域特化。
+
+## 总体判断
+
+1. 当前架构确实有明显的 Spring/中间件框架影子。
+2. 但并非所有模块都适合“以对标为主线”推进。
+3. 推荐策略：`A 类按对标推进 + B 类按抽象原则推进 + C 类保持 WoW 特化`。
+
+---
+
+## A 类：可直接对标（优先）
+
+### A1. Stream Pipeline + 插件体系
+
+1. 现有实现：
+- `Domain/Stream/Ingress/StreamEventDispatcher.lua`
+- `Domain/Stream/Rules/StreamRuleEngine.lua`
+- `Domain/Stream/Render/MessageFormatter.lua`
+- `Domain/Stream/Render/Transformers/StreamHighlighter.lua`
+
+2. 对标框架：
+- Koa/Express middleware
+- ASP.NET Core middleware pipeline
+- Spring WebFlux filter chain（思路层）
+
+3. 可抽象内核：
+- 阶段流水线、priority 排序、异常隔离
+- kind strategy/formatter/highlighter 注册协议
+
+### A2. Settings Orchestrator + Subscriber
+
+1. 现有实现：
+- `Domain/Settings/SettingsOrchestrator.lua`
+- `Domain/Settings/SettingsSubscriberRegistry.lua`
+
+2. 对标框架：
+- Spring `ApplicationEvent + Ordered`
+- .NET hosted pipeline（阶段化编排）
+
+3. 可抽象内核：
+- phase + priority + key 订阅模型
+- commit context（traceId/reason/scope）
+
+### A3. 轻量 DI 容器
+
+1. 现有实现：
+- `App/DI/Container.lua`
+- `App/Container.lua`
+
+2. 对标框架：
+- Spring IoC
+- .NET DI container
+
+3. 可抽象内核：
+- value/singleton/factory
+- 依赖链解析、循环检测、freeze
+
+---
+
+## B 类：只能概念对标（谨慎）
+
+### B1. Feature/Capability Runtime Governance
+
+1. 现有实现：
+- `Infrastructure/Runtime/FeatureRegistry.lua`
+- `Infrastructure/Runtime/CapabilityPolicyEngine.lua`
+- `Infrastructure/Runtime/RuntimeCoordinator.lua`
+
+2. 可参考对象（仅理念）：
+- LaunchDarkly/Unleash（能力门控）
+- Kubernetes reconcile loop（状态重协调）
+
+3. 不应硬对标点：
+- 这里是“运行态能力矩阵 + 游戏环境事件切换”，不是标准 SaaS feature flag 平台。
+
+### B2. Registry Compiler（Stream/Action）
+
+1. 现有实现：
+- `Domain/Stream/Registry/StreamRegistry.lua`
+- `Infrastructure/Runtime/StreamRegistryCompiler.lua`
+- `Domain/Stream/Actions/StreamActionRegistry.lua`
+
+2. 可参考对象（仅理念）：
+- Terraform/Babel/AST 多 pass 编译思想
+
+3. 不应硬对标点：
+- 这是运行时配置编译，不是通用语言编译器，也不是 IaC plan/apply 体系。
+
+### B3. Schema 驱动设置 UI
+
+1. 现有实现：
+- `Domain/Settings/SettingsService.lua`
+- `Domain/Settings/SettingsControls.lua`
+
+2. 可参考对象（仅理念）：
+- Django Form / JSON Schema Form
+
+3. 不应硬对标点：
+- 依赖 WoW `Settings.*` 原生 API，UI 生命周期与 Web 表单库差异很大。
+
+---
+
+## C 类：不宜对标（保持领域特化）
+
+### C1. WoW Transport 与 Chat 协议细节
+
+1. 代表实现：`Infrastructure/WowApi/*`、`CHAT_MSG_*` 映射链路。
+2. 原因：
+- 强平台绑定（Blizzard API、事件语义、ChatFrame 机制）。
+- 抽成“通用框架”收益低，适配成本高。
+
+### C2. Shelf/Kit 的游戏交互模型
+
+1. 代表实现：`Domain/Shelf/*`、`Domain/Stream/Actions/StreamActionRegistry.lua`（readycheck、roll、leave 等）。
+2. 原因：
+- 操作语义是 WoW 专属动作，不具备跨域复用价值。
+
+### C3. 本地化与素材资源组织
+
+1. 代表实现：`Locales/*`、`Media/*`。
+2. 原因：
+- 更接近内容资产管理，不是框架能力。
+
+---
+
+## 推荐推进方式（结构化）
+
+1. 主线：对 A 类做“对标式抽象”。
+2. 辅线：对 B 类做“原则式抽象”，只复用架构思想，不追求 API 同构。
+3. 保留：C 类继续留在 addon 业务层，不纳入框架化 KPI。
+
+## 迁移优先级（按收益/风险）
+
+1. `stream-core`（A1）
+2. `settings-orchestrator-core`（A2）
+3. `di-core`（A3）
+4. `runtime-governor-core`（B1）
+5. `registry-compiler-core`（B2）
+6. `settings-schema-core`（B3）
+
+## 非目标
+
+1. 不追求“看起来像 Spring”而牺牲 Lua/WoW 适配性。
+2. 不引入注解反射式模型。
+3. 不在 C 类模块做通用框架化拆分。
+
+## 统一判断标准（后续评审使用）
+
+1. 若模块 70% 以上逻辑与 WoW API 强耦合，则归 C 类。
+2. 若模块可在不改语义下脱离 WoW API 运行，则优先归 A 类。
+3. 若仅能复用设计思想、无法复用接口形状，则归 B 类。

--- a/Docs/0024-PLAN-step-01-stream-core-cutover.md
+++ b/Docs/0024-PLAN-step-01-stream-core-cutover.md
@@ -1,0 +1,80 @@
+---
+id: 0024
+priority: P1
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023, #0017, #0018]
+status: ACTIVE
+---
+
+# STEP 01：stream-core 抽离与切换（不做向后兼容）
+
+## 目标
+
+1. 将消息处理主链路抽为 `stream-core`：pipeline + rule + formatter + highlighter 插件协议。
+2. 旧入口直接替换，不保留 alias/桥接层。
+3. 本步完成后，WoW 相关逻辑仅存在于 adapter 层。
+
+## 约束
+
+1. 不向后兼容：删除旧调用路径，不双写。
+2. 逐步完成：仅处理 stream 相关链路，不触及 settings/di 主体。
+3. 本文仅定义本步改造。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-01-stream-core-cutover`。
+2. 本步所有代码与文档只在该分支实现。
+3. 合入后再开启下一步分支，不并行混改。
+
+## Libs 落位可行性
+
+1. 结论：可行，建议放入 `Libs/TinyCore/Stream/*`。
+2. 理由：`stream-core` 属于通用机制层，适合与 `Libs/TinyReactor` 同级管理。
+3. 约束：
+- WoW API 依赖保留在 `Domain/` 或 `Infrastructure/WowApi/` adapter。
+- `TinyChaton.toc` 需提前加载 `Libs/TinyCore/Stream/*`。
+
+## 范围
+
+1. In Scope
+- `Domain/Stream/Ingress/StreamEventDispatcher.lua`
+- `Domain/Stream/Rules/*`
+- `Domain/Stream/Render/*`
+- `Infrastructure/WowApi/ChatGateway.lua`（仅 adapter 对接）
+
+2. Out of Scope
+- Settings 页面和 Orchestrator 行为调整。
+- Shelf/Kit 业务动作语义。
+
+## 目标结构
+
+1. `Libs/TinyCore/Stream/Pipeline.lua`
+2. `Libs/TinyCore/Stream/RuleEngine.lua`
+3. `Libs/TinyCore/Stream/RenderEngine.lua`
+4. `Infrastructure/WowApi/StreamTransportAdapter.lua`
+
+## 执行步骤
+
+1. 定义 core 契约：`context`、`stage`、`plugin`、`decision`。
+2. 把 Dispatcher 的阶段执行迁移到 `Pipeline`。
+3. 把 `RegisterKindStrategy/RegisterKindFormatter/RegisterKindHighlighter` 统一到 core 注册器。
+4. Adapter 对接 ChatFrame 过滤器与显示变换。
+5. 删除旧主流程调用点。
+
+## 交付件
+
+1. core 模块代码与最小 README。
+2. WoW adapter 对接层。
+3. 迁移后的调用路径图。
+
+## 验收标准
+
+1. 新增 kind 插件无需修改 pipeline 主流程。
+2. 运行时仍能完成：过滤、转换、渲染、高亮、持久化。
+3. 旧入口不再被引用（`rg` 验证）。
+
+## 回滚策略
+
+1. 仅允许“整步回滚”（回退整个 STEP 01 提交）。
+2. 不提供运行时开关回退。

--- a/Docs/0025-PLAN-step-02-settings-orchestrator-cutover.md
+++ b/Docs/0025-PLAN-step-02-settings-orchestrator-cutover.md
@@ -1,0 +1,76 @@
+---
+id: 0025
+priority: P1
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023, #0022]
+status: ACTIVE
+---
+
+# STEP 02：settings-orchestrator-core 切换（不做向后兼容）
+
+## 目标
+
+1. 固化 `CommitSettings -> Orchestrator` 为唯一入口。
+2. 所有 settings 应用动作通过 subscriber 编排执行。
+3. 移除中心化直调链路（不保留旧名或兼容壳）。
+
+## 约束
+
+1. 不向后兼容：删除旧入口与旧调用。
+2. 逐步完成：仅处理 settings 编排，不改 stream 规则。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-02-settings-orchestrator-cutover`。
+2. 必须基于已合入的 STEP 01 主干创建。
+3. 不与后续步骤混合提交。
+
+## Libs 落位可行性
+
+1. 结论：可行，建议放入 `Libs/TinyCore/SettingsOrchestrator/*`。
+2. 理由：phase/priority 编排器是跨模块机制层。
+3. 约束：
+- 页面触发与 WoW `Settings.*` API 保留在 `Domain/Settings/*` adapter。
+- `TinyChaton.toc` 加载顺序需保证 core 先于 subscriber 注册代码。
+
+## 范围
+
+1. In Scope
+- `Domain/Settings/SettingsOrchestrator.lua`
+- `Domain/Settings/SettingsSubscriberRegistry.lua`
+- 所有 `RegisterSettingsSubscriber` 调用模块
+
+2. Out of Scope
+- Settings UI 样式/布局。
+- Profile 数据模型重构。
+
+## 目标结构
+
+1. `Libs/TinyCore/SettingsOrchestrator/Orchestrator.lua`
+2. `Libs/TinyCore/SettingsOrchestrator/SubscriberRegistry.lua`
+3. `Libs/TinyCore/SettingsOrchestrator/CommitContext.lua`
+4. `Domain/Settings/SettingsCommitBridge.lua`
+
+## 执行步骤
+
+1. 抽离 phase/priority/sort/validate 逻辑到 core。
+2. 将现有 subscriber 全量迁移到统一契约。
+3. 所有 settings 变更触发统一改到 `CommitSettings`。
+4. 删除旧串行 apply 调用路径。
+
+## 交付件
+
+1. orchestrator core 模块。
+2. subscriber 清单（key/phase/priority）。
+3. 迁移后触发点矩阵（页面、reset、profile、runtime 触发）。
+
+## 验收标准
+
+1. `CommitSettings` 是唯一设置提交入口。
+2. 顺序仅由 phase+priority 决定。
+3. 缺失/重复 subscriber key 启动即报错。
+
+## 回滚策略
+
+1. 整步回滚，不保留运行时 fallback。

--- a/Docs/0026-PLAN-step-03-di-core-cutover.md
+++ b/Docs/0026-PLAN-step-03-di-core-cutover.md
@@ -1,0 +1,74 @@
+---
+id: 0026
+priority: P1
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023, #0022]
+status: ACTIVE
+---
+
+# STEP 03：di-core 单轨切换（不做向后兼容）
+
+## 目标
+
+1. 形成唯一 DI 入口：容器解析。
+2. 删除 `addon.XXX` 作为服务注入通道的模式。
+3. 启动期完成依赖图 fail-fast 校验。
+
+## 约束
+
+1. 不向后兼容：不保留双轨模式。
+2. 逐步完成：只收敛依赖获取方式，不改业务语义。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-03-di-core-cutover`。
+2. 必须基于已合入的 STEP 02 主干创建。
+3. 本步只提交 DI 改造与必要适配。
+
+## Libs 落位可行性
+
+1. 结论：可行，建议放入 `Libs/TinyCore/DI/*`。
+2. 理由：容器属于基础设施级能力，独立于业务域。
+3. 约束：
+- `App/Bootstrap/ContainerSetup.lua` 作为装配入口保留在 App 层。
+- `TinyChaton.toc` 确保 DI core 先加载。
+
+## 范围
+
+1. In Scope
+- `App/DI/Container.lua`
+- `App/Container.lua`
+- 各业务模块的依赖获取语句
+
+2. Out of Scope
+- 新增高级 DI 特性（注解、AOP、自动扫描）。
+
+## 目标结构
+
+1. `Libs/TinyCore/DI/Container.lua`
+2. `Libs/TinyCore/DI/Validation.lua`
+3. `App/Bootstrap/ContainerSetup.lua`（仅装配）
+
+## 执行步骤
+
+1. 完成容器 API 冻结：register/resolve/has/tryResolve/freeze。
+2. 迁移业务依赖读取到 `ResolveRequiredService/ResolveOptionalService`。
+3. 新增启动校验：未注册、循环依赖、工厂异常。
+4. 删除双轨注入残留。
+
+## 交付件
+
+1. 单轨 DI 实现与装配代码。
+2. 依赖图校验日志输出。
+3. 迁移清单（模块 -> 服务名）。
+
+## 验收标准
+
+1. 业务层不再新增 `addon.XXX` 注入读取。
+2. 缺服务在启动期明确失败。
+3. 容器冻结后禁止新增注册。
+
+## 回滚策略
+
+1. 整步回滚，不做双轨重开。

--- a/Docs/0027-PLAN-step-04-runtime-governor-core.md
+++ b/Docs/0027-PLAN-step-04-runtime-governor-core.md
@@ -1,0 +1,75 @@
+---
+id: 0027
+priority: P2
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023]
+status: ACTIVE
+---
+
+# STEP 04：runtime-governor-core 抽离（不做向后兼容）
+
+## 目标
+
+1. 抽离 feature/capability/reconcile 为独立治理内核。
+2. 将运行模式切换与特性启停关系标准化。
+3. 保留 WoW 事件监听在 adapter，不进入 core。
+
+## 约束
+
+1. 不向后兼容：旧 feature 管理路径直接替换。
+2. 逐步完成：只处理运行态治理。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-04-runtime-governor-core`。
+2. 必须基于已合入的 STEP 03 主干创建。
+3. 本步不混入 registry/settings-schema 改造。
+
+## Libs 落位可行性
+
+1. 结论：可行，建议放入 `Libs/TinyCore/RuntimeGovernor/*`。
+2. 理由：特性治理属于通用运行时控制平面。
+3. 约束：
+- 环境感知事件（`PLAYER_ENTERING_WORLD` 等）保留在 adapter。
+- 防止 core 直接调用 WoW API。
+
+## 范围
+
+1. In Scope
+- `Infrastructure/Runtime/FeatureRegistry.lua`
+- `Infrastructure/Runtime/CapabilityPolicyEngine.lua`
+- `Infrastructure/Runtime/RuntimeCoordinator.lua`
+
+2. Out of Scope
+- 具体业务 feature 的实现逻辑。
+
+## 目标结构
+
+1. `Libs/TinyCore/RuntimeGovernor/CapabilityMatrix.lua`
+2. `Libs/TinyCore/RuntimeGovernor/FeatureRegistry.lua`
+3. `Libs/TinyCore/RuntimeGovernor/Reconciler.lua`
+4. `Infrastructure/WowApi/RuntimeModeWatcher.lua`
+
+## 执行步骤
+
+1. 标准化 capability 判定接口。
+2. feature 注册对象统一字段（requires/plane/hooks）。
+3. 将模式变化触发统一走 reconcile。
+4. 删除旧管理入口。
+
+## 交付件
+
+1. runtime governor core。
+2. mode -> capability 矩阵文档。
+3. feature 启停时序图。
+
+## 验收标准
+
+1. 模式变化后 feature 状态可预测且可重演。
+2. 未满足 capability 的 feature 必定禁用。
+3. 旧入口调用为 0。
+
+## 回滚策略
+
+1. 整步回滚。

--- a/Docs/0028-PLAN-step-05-registry-compiler-core.md
+++ b/Docs/0028-PLAN-step-05-registry-compiler-core.md
@@ -1,0 +1,74 @@
+---
+id: 0028
+priority: P2
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023, #0012]
+status: ACTIVE
+---
+
+# STEP 05：registry-compiler-core 抽离（不做向后兼容）
+
+## 目标
+
+1. 将声明式 registry 编译流程抽离为通用 core。
+2. 固化 pass：schema -> normalize -> index -> validate -> freeze。
+3. 运行期只读消费编译产物。
+
+## 约束
+
+1. 不向后兼容：旧编译路径删除。
+2. 逐步完成：只处理 registry 编译，不改业务定义语义。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-05-registry-compiler-core`。
+2. 必须基于已合入的 STEP 04 主干创建。
+3. 本步只提交 compiler 及其消费侧迁移。
+
+## Libs 落位可行性
+
+1. 结论：可行，建议放入 `Libs/TinyCore/RegistryCompiler/*`。
+2. 理由：多 pass 编译器是机制层能力，与业务定义解耦。
+3. 约束：
+- stream/action 业务 schema 仍留在 `Domain/*`。
+- core 仅处理 schema 契约，不包含 WoW 事件常量语义判断。
+
+## 范围
+
+1. In Scope
+- `Infrastructure/Runtime/StreamRegistryCompiler.lua`
+- `Domain/Stream/Registry/StreamRegistry.lua`
+- `Domain/Stream/Actions/StreamActionRegistry.lua`（声明驱动部分）
+
+2. Out of Scope
+- Shelf 视觉/布局逻辑。
+
+## 目标结构
+
+1. `Libs/TinyCore/RegistryCompiler/Compiler.lua`
+2. `Libs/TinyCore/RegistryCompiler/Passes/*`
+3. `Libs/TinyCore/RegistryCompiler/Artifact.lua`
+
+## 执行步骤
+
+1. 抽离 pass 接口与执行器。
+2. 把 stream/action schema 迁移到统一 compiler 输入。
+3. 输出冻结 artifact 并替换消费侧读取逻辑。
+4. 删除旧编译器实现。
+
+## 交付件
+
+1. 通用 compiler core。
+2. pass 列表与输入输出契约。
+3. 冻结 artifact 结构文档。
+
+## 验收标准
+
+1. 非法 schema 在编译期失败而非运行期失败。
+2. 运行期无动态改写编译产物。
+3. stream/action 消费侧全部走新 artifact。
+
+## 回滚策略
+
+1. 整步回滚。

--- a/Docs/0029-PLAN-step-06-settings-schema-core.md
+++ b/Docs/0029-PLAN-step-06-settings-schema-core.md
@@ -1,0 +1,74 @@
+---
+id: 0029
+priority: P2
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0023]
+status: ACTIVE
+---
+
+# STEP 06：settings-schema-core 抽离（不做向后兼容）
+
+## 目标
+
+1. 抽离 settings schema、验证、控件映射为 core。
+2. WoW `Settings.*` 仅作为 renderer adapter。
+3. 设置变更统一桥接到 orchestrator commit。
+
+## 约束
+
+1. 不向后兼容：旧控件工厂路径直接替换。
+2. 逐步完成：仅处理 settings schema 与 UI factory。
+
+## 独立分支策略
+
+1. 分支名：`codex/step-06-settings-schema-core`。
+2. 必须基于已合入的 STEP 05 主干创建。
+3. 本步仅提交 schema-core 与 renderer 适配。
+
+## Libs 落位可行性
+
+1. 结论：部分可行。
+2. 放入 `Libs/TinyCore/SettingsSchema/*` 的部分：schema registry、validator、model。
+3. 保留在 `Domain/Settings/*` 的部分：WoW `Settings.*` renderer 与页面接线。
+4. 原因：核心验证逻辑可复用，UI 渲染强依赖 WoW 生命周期。
+
+## 范围
+
+1. In Scope
+- `Domain/Settings/SettingsService.lua`
+- `Domain/Settings/SettingsControls.lua`
+- `Domain/Settings/Pages/*`（schema 声明部分）
+
+2. Out of Scope
+- 文案与本地化资源调整。
+
+## 目标结构
+
+1. `Libs/TinyCore/SettingsSchema/SchemaRegistry.lua`
+2. `Libs/TinyCore/SettingsSchema/Validator.lua`
+3. `Libs/TinyCore/SettingsSchema/ControlModel.lua`
+4. `Domain/Settings/SettingsRenderer.lua`
+
+## 执行步骤
+
+1. 定义 schema 元模型（type/default/validator/ui/scope）。
+2. 抽离 Validate/Export/Reset 的核心逻辑。
+3. 页面层改为声明 schema，renderer 负责落地 UI。
+4. 删除旧控件工厂实现。
+
+## 交付件
+
+1. settings schema core。
+2. 页面 schema 清单。
+3. renderer 对接与 commit 桥接说明。
+
+## 验收标准
+
+1. 设置校验逻辑可脱离 WoW API 单独运行。
+2. 控件创建由 schema 驱动，不再散落自定义流程。
+3. 变更提交统一触发 orchestrator。
+
+## 回滚策略
+
+1. 整步回滚。

--- a/Docs/0030-PLAN-branching-and-libs-placement-baseline.md
+++ b/Docs/0030-PLAN-branching-and-libs-placement-baseline.md
@@ -1,0 +1,46 @@
+---
+id: 0030
+priority: P1
+created: 2026-03-05
+updated: 2026-03-05
+relates: [#0024, #0025, #0026, #0027, #0028, #0029]
+status: ACTIVE
+---
+
+# 分支与 Libs 落位基线（适用于 STEP 01-06）
+
+## 分支基线
+
+1. 每一步独立分支实现，禁止在同一分支跨步开发。
+2. 分支顺序与命名固定：
+- `codex/step-01-stream-core-cutover`
+- `codex/step-02-settings-orchestrator-cutover`
+- `codex/step-03-di-core-cutover`
+- `codex/step-04-runtime-governor-core`
+- `codex/step-05-registry-compiler-core`
+- `codex/step-06-settings-schema-core`
+3. 下一步分支必须从“上一步已合入主干”的最新提交创建。
+
+## Libs 落位基线
+
+1. 新增统一机制层目录：`Libs/TinyCore/`。
+2. 子目录规划：
+- `Libs/TinyCore/Stream/`
+- `Libs/TinyCore/SettingsOrchestrator/`
+- `Libs/TinyCore/DI/`
+- `Libs/TinyCore/RuntimeGovernor/`
+- `Libs/TinyCore/RegistryCompiler/`
+- `Libs/TinyCore/SettingsSchema/`
+3. 强 WoW 依赖代码不得进入 `Libs/TinyCore/*`，应保留在 `Domain/*` 或 `Infrastructure/WowApi/*` adapter。
+
+## TOC 加载顺序规则
+
+1. `TinyChaton.toc` 中 `Libs/TinyCore/*` 必须早于 `Infrastructure/*`、`App/*`、`Domain/*` 消费方。
+2. 每个 STEP 合入时同步更新 TOC，禁止“代码已迁移但 TOC 未接线”。
+3. 未接入 TOC 的 core 文件视为未完成交付。
+
+## 非目标
+
+1. 不引入外部依赖管理器。
+2. 不把现有 `Libs` 目录改造成第三方 vendor 语义。
+3. 不在本基线文档内定义业务行为变化。


### PR DESCRIPTION
## Summary\n- add framework extraction assessment with direct/partial/non-benchmarkable mapping\n- add step-by-step implementation plans (step 01-06), one doc per step\n- add branching and Libs/TinyCore placement baseline\n\n## Notes\n- docs-only change\n- explicitly states no backward compatibility during step implementations\n