### PR TITLE
refactor(runtime): extract runtime governor core to Libs/TinyCore (step 04)

### DIFF
--- a/Infrastructure/Runtime/CapabilityPolicyEngine.lua
+++ b/Infrastructure/Runtime/CapabilityPolicyEngine.lua
@@ -25,13 +25,16 @@ local CAP_MATRIX = {
     },
 }
 
+if not addon.TinyCoreRuntimeCapabilityMatrix or type(addon.TinyCoreRuntimeCapabilityMatrix.New) ~= "function" then
+    error("TinyCore Runtime CapabilityMatrix is not initialized")
+end
+
+addon.RuntimeCapabilityMatrix = addon.RuntimeCapabilityMatrix
+    or addon.TinyCoreRuntimeCapabilityMatrix:New(CAP_MATRIX, "ACTIVE")
+
 function addon:Can(capability)
-    if not capability then
-        return true
-    end
     local mode = self.GetChatRuntimeMode and self:GetChatRuntimeMode() or "ACTIVE"
-    local row = CAP_MATRIX[mode] or CAP_MATRIX.ACTIVE
-    return row[capability] == true
+    return addon.RuntimeCapabilityMatrix:Can(mode, capability)
 end
 
 function addon:EmitChatMessage(text, wowChatType, language, target)

--- a/Infrastructure/Runtime/FeatureRegistry.lua
+++ b/Infrastructure/Runtime/FeatureRegistry.lua
@@ -1,109 +1,42 @@
 local addonName, addon = ...
 
-addon.FeatureRegistry = addon.FeatureRegistry or {
-    entries = {},
-}
+if not addon.TinyCoreRuntimeFeatureRegistry or type(addon.TinyCoreRuntimeFeatureRegistry.New) ~= "function" then
+    error("TinyCore Runtime FeatureRegistry is not initialized")
+end
 
+addon.FeatureRegistry = addon.FeatureRegistry or addon.TinyCoreRuntimeFeatureRegistry:New({
+    entries = {},
+})
 local Registry = addon.FeatureRegistry
 
 function addon:RegisterFeature(name, spec)
-    if not name or name == "" or type(spec) ~= "table" then
-        return
+    local finalSpec = type(spec) == "table" and spec or {}
+    if finalSpec.plane == nil then
+        finalSpec.plane = (addon.RUNTIME_PLANES and addon.RUNTIME_PLANES.UI_ONLY) or "UI_ONLY"
     end
-
-    local entry = Registry.entries[name]
-    if not entry then
-        entry = {
-            name = name,
-            enabled = false,
-        }
-        Registry.entries[name] = entry
-    end
-
-    entry.requires = spec.requires or {}
-    entry.plane = spec.plane or (addon.RUNTIME_PLANES and addon.RUNTIME_PLANES.UI_ONLY) or "UI_ONLY"
-    entry.enabledWhenBypass = spec.enabledWhenBypass == true
-    entry.onEnable = spec.onEnable
-    entry.onDisable = spec.onDisable
-end
-
-local function CanEnable(entry)
-    if not entry then return false end
-    if addon.IsPlaneAllowed and not addon:IsPlaneAllowed(entry.plane, entry.enabledWhenBypass) then
-        return false
-    end
-    local requires = entry.requires or {}
-    for _, capability in ipairs(requires) do
-        if not addon:Can(capability) then
-            return false
-        end
-    end
-    return true
-end
-
-local function GetSortedEntries()
-    local entries = {}
-    for _, entry in pairs(Registry.entries) do
-        entries[#entries + 1] = entry
-    end
-    table.sort(entries, function(a, b)
-        return tostring(a.name) < tostring(b.name)
-    end)
-    return entries
-end
-
-local function EnableEntry(entry)
-    if not entry or entry.enabled then return end
-    if type(entry.onEnable) == "function" then
-        local ok, err = pcall(entry.onEnable)
-        if not ok then
-            entry.enabled = false
-            error(string.format("Feature %s enable failed: %s", tostring(entry.name), tostring(err)))
-        end
-    end
-    entry.enabled = true
-end
-
-local function DisableEntry(entry)
-    if not entry or not entry.enabled then return end
-    if type(entry.onDisable) == "function" then
-        local ok, err = pcall(entry.onDisable)
-        if not ok then
-            entry.enabled = true
-            error(string.format("Feature %s disable failed: %s", tostring(entry.name), tostring(err)))
-        end
-    end
-    entry.enabled = false
+    Registry:Register(name, finalSpec)
 end
 
 function addon:DisableFeaturesByPlane(plane)
-    for _, entry in ipairs(GetSortedEntries()) do
-        if plane == nil or entry.plane == plane then
-            DisableEntry(entry)
-        end
-    end
+    Registry:DisableByPlane(plane)
 end
 
 function addon:ReconcileFeatures(options)
-    local opts = type(options) == "table" and options or {}
-    if opts.teardownAll == true then
-        self:DisableFeaturesByPlane(nil)
-    elseif opts.teardownPlane then
-        self:DisableFeaturesByPlane(opts.teardownPlane)
-    end
-
-    for _, entry in ipairs(GetSortedEntries()) do
-        if CanEnable(entry) then
-            EnableEntry(entry)
-        else
-            DisableEntry(entry)
-        end
-    end
+    Registry:Reconcile({
+        can = function(capability)
+            return addon:Can(capability)
+        end,
+        isPlaneAllowed = function(plane, enabledWhenBypass)
+            if addon.IsPlaneAllowed then
+                return addon:IsPlaneAllowed(plane, enabledWhenBypass)
+            end
+            return true
+        end,
+    }, options)
 end
 
 function addon:IsFeatureEnabled(name)
-    local entry = Registry.entries and Registry.entries[name]
-    return entry and entry.enabled or false
+    return Registry:IsEnabled(name)
 end
 
 function addon:InitFeatureRegistry()

--- a/Infrastructure/Runtime/RuntimeCoordinator.lua
+++ b/Infrastructure/Runtime/RuntimeCoordinator.lua
@@ -12,20 +12,39 @@ local WATCHED_EVENTS = {
 }
 
 function Coordinator:RefreshMode()
-    if not addon.EnvGate or not addon.SetChatRuntimeMode then
-        return
+    if not self.reconciler then
+        if not addon.TinyCoreRuntimeReconciler or type(addon.TinyCoreRuntimeReconciler.New) ~= "function" then
+            error("TinyCore Runtime Reconciler is not initialized")
+        end
+        self.reconciler = addon.TinyCoreRuntimeReconciler:New({
+            resolveMode = function()
+                if not addon.EnvGate or type(addon.EnvGate.ResolveMode) ~= "function" then
+                    return nil, nil
+                end
+                return addon.EnvGate:ResolveMode()
+            end,
+            setMode = function(mode, reason)
+                if not addon.SetChatRuntimeMode then
+                    return false
+                end
+                return addon:SetChatRuntimeMode(mode, reason)
+            end,
+            onModeChanged = function()
+                if addon.DisableFeaturesByPlane then
+                    addon:DisableFeaturesByPlane(addon.RUNTIME_PLANES and addon.RUNTIME_PLANES.CHAT_DATA or "CHAT_DATA")
+                end
+                if addon.ReconcileFeatures then
+                    addon:ReconcileFeatures()
+                end
+            end,
+            onAfterReconcile = function()
+                if addon.RefreshShelf then
+                    addon:RefreshShelf()
+                end
+            end,
+        })
     end
-    local mode, reason = addon.EnvGate:ResolveMode()
-    local changed = addon:SetChatRuntimeMode(mode, reason)
-    if changed and addon.DisableFeaturesByPlane then
-        addon:DisableFeaturesByPlane(addon.RUNTIME_PLANES and addon.RUNTIME_PLANES.CHAT_DATA or "CHAT_DATA")
-    end
-    if changed and addon.ReconcileFeatures then
-        addon:ReconcileFeatures()
-    end
-    if changed and addon.RefreshShelf then
-        addon:RefreshShelf()
-    end
+    self.reconciler:RefreshMode()
 end
 
 function Coordinator:OnEvent(event, ...)

--- a/Libs/TinyCore/RuntimeGovernor/CapabilityMatrix.lua
+++ b/Libs/TinyCore/RuntimeGovernor/CapabilityMatrix.lua
@@ -1,0 +1,21 @@
+local addonName, addon = ...
+
+addon.TinyCoreRuntimeCapabilityMatrix = addon.TinyCoreRuntimeCapabilityMatrix or {}
+local CapabilityMatrix = addon.TinyCoreRuntimeCapabilityMatrix
+CapabilityMatrix.__index = CapabilityMatrix
+
+function CapabilityMatrix:New(matrix, defaultMode)
+    return setmetatable({
+        matrix = type(matrix) == "table" and matrix or {},
+        defaultMode = type(defaultMode) == "string" and defaultMode or "ACTIVE",
+    }, self)
+end
+
+function CapabilityMatrix:Can(mode, capability)
+    if not capability then
+        return true
+    end
+    local runtimeMode = type(mode) == "string" and mode or self.defaultMode
+    local row = self.matrix[runtimeMode] or self.matrix[self.defaultMode] or {}
+    return row[capability] == true
+end

--- a/Libs/TinyCore/RuntimeGovernor/FeatureRegistry.lua
+++ b/Libs/TinyCore/RuntimeGovernor/FeatureRegistry.lua
@@ -1,0 +1,117 @@
+local addonName, addon = ...
+
+addon.TinyCoreRuntimeFeatureRegistry = addon.TinyCoreRuntimeFeatureRegistry or {}
+local FeatureRegistry = addon.TinyCoreRuntimeFeatureRegistry
+FeatureRegistry.__index = FeatureRegistry
+
+local function CanEnable(entry, deps)
+    if not entry then
+        return false
+    end
+    if deps.isPlaneAllowed and not deps.isPlaneAllowed(entry.plane, entry.enabledWhenBypass) then
+        return false
+    end
+    local requires = entry.requires or {}
+    for _, capability in ipairs(requires) do
+        if deps.can and not deps.can(capability) then
+            return false
+        end
+    end
+    return true
+end
+
+local function GetSortedEntries(entries)
+    local out = {}
+    for _, entry in pairs(entries or {}) do
+        out[#out + 1] = entry
+    end
+    table.sort(out, function(a, b)
+        return tostring(a.name) < tostring(b.name)
+    end)
+    return out
+end
+
+local function EnableEntry(entry)
+    if not entry or entry.enabled then
+        return
+    end
+    if type(entry.onEnable) == "function" then
+        local ok, err = pcall(entry.onEnable)
+        if not ok then
+            entry.enabled = false
+            error(string.format("Feature %s enable failed: %s", tostring(entry.name), tostring(err)))
+        end
+    end
+    entry.enabled = true
+end
+
+local function DisableEntry(entry)
+    if not entry or not entry.enabled then
+        return
+    end
+    if type(entry.onDisable) == "function" then
+        local ok, err = pcall(entry.onDisable)
+        if not ok then
+            entry.enabled = true
+            error(string.format("Feature %s disable failed: %s", tostring(entry.name), tostring(err)))
+        end
+    end
+    entry.enabled = false
+end
+
+function FeatureRegistry:New(opts)
+    local options = type(opts) == "table" and opts or {}
+    return setmetatable({
+        entries = options.entries or {},
+    }, self)
+end
+
+function FeatureRegistry:Register(name, spec)
+    if not name or name == "" or type(spec) ~= "table" then
+        return
+    end
+    local entry = self.entries[name]
+    if not entry then
+        entry = {
+            name = name,
+            enabled = false,
+        }
+        self.entries[name] = entry
+    end
+    entry.requires = spec.requires or {}
+    entry.plane = spec.plane or "UI_ONLY"
+    entry.enabledWhenBypass = spec.enabledWhenBypass == true
+    entry.onEnable = spec.onEnable
+    entry.onDisable = spec.onDisable
+end
+
+function FeatureRegistry:DisableByPlane(plane)
+    for _, entry in ipairs(GetSortedEntries(self.entries)) do
+        if plane == nil or entry.plane == plane then
+            DisableEntry(entry)
+        end
+    end
+end
+
+function FeatureRegistry:Reconcile(deps, options)
+    local opts = type(options) == "table" and options or {}
+    if opts.teardownAll == true then
+        self:DisableByPlane(nil)
+    elseif opts.teardownPlane then
+        self:DisableByPlane(opts.teardownPlane)
+    end
+
+    local dependencyFns = type(deps) == "table" and deps or {}
+    for _, entry in ipairs(GetSortedEntries(self.entries)) do
+        if CanEnable(entry, dependencyFns) then
+            EnableEntry(entry)
+        else
+            DisableEntry(entry)
+        end
+    end
+end
+
+function FeatureRegistry:IsEnabled(name)
+    local entry = self.entries and self.entries[name]
+    return entry and entry.enabled or false
+end

--- a/Libs/TinyCore/RuntimeGovernor/Reconciler.lua
+++ b/Libs/TinyCore/RuntimeGovernor/Reconciler.lua
@@ -1,0 +1,30 @@
+local addonName, addon = ...
+
+addon.TinyCoreRuntimeReconciler = addon.TinyCoreRuntimeReconciler or {}
+local Reconciler = addon.TinyCoreRuntimeReconciler
+Reconciler.__index = Reconciler
+
+function Reconciler:New(opts)
+    local options = type(opts) == "table" and opts or {}
+    return setmetatable({
+        resolveMode = options.resolveMode,
+        setMode = options.setMode,
+        onModeChanged = options.onModeChanged,
+        onAfterReconcile = options.onAfterReconcile,
+    }, self)
+end
+
+function Reconciler:RefreshMode()
+    if type(self.resolveMode) ~= "function" or type(self.setMode) ~= "function" then
+        return false
+    end
+    local mode, reason = self.resolveMode()
+    local changed = self.setMode(mode, reason) == true
+    if changed and type(self.onModeChanged) == "function" then
+        self.onModeChanged(mode, reason)
+    end
+    if changed and type(self.onAfterReconcile) == "function" then
+        self.onAfterReconcile(mode, reason)
+    end
+    return changed
+end

--- a/TinyChaton.toc
+++ b/TinyChaton.toc
@@ -30,6 +30,9 @@ Libs\TinyCore\SettingsOrchestrator\SubscriberRegistry.lua
 Libs\TinyCore\SettingsOrchestrator\Orchestrator.lua
 Libs\TinyCore\DI\Container.lua
 Libs\TinyCore\DI\Validation.lua
+Libs\TinyCore\RuntimeGovernor\CapabilityMatrix.lua
+Libs\TinyCore\RuntimeGovernor\FeatureRegistry.lua
+Libs\TinyCore\RuntimeGovernor\Reconciler.lua
 
 Infrastructure\Runtime\Logger.lua
 App\DI\Container.lua


### PR DESCRIPTION
## Summary
- extract runtime capability matrix core to `Libs/TinyCore/RuntimeGovernor/CapabilityMatrix.lua`
- extract runtime feature registry core to `Libs/TinyCore/RuntimeGovernor/FeatureRegistry.lua`
- extract runtime mode reconciler core to `Libs/TinyCore/RuntimeGovernor/Reconciler.lua`
- refactor runtime adapters:
  - `Infrastructure/Runtime/CapabilityPolicyEngine.lua` delegates to TinyCore capability matrix
  - `Infrastructure/Runtime/FeatureRegistry.lua` delegates to TinyCore feature registry
  - `Infrastructure/Runtime/RuntimeCoordinator.lua` delegates mode refresh workflow to TinyCore reconciler
- wire TinyCore runtime governor files into `TinyChaton.toc` before infrastructure consumers

## Scope
- step 04 implementation following docs 0027 and 0030
- no backward-compat bridge added

## Verification
- `luac -p` passed for touched runtime files
