### PR TITLE
refactor(actions): move action registry compilation into TinyCore

### DIFF
--- a/Domain/Stream/Actions/StreamActionRegistry.lua
+++ b/Domain/Stream/Actions/StreamActionRegistry.lua
@@ -198,112 +198,25 @@ addon.ACTION_DEFINITIONS = {
 -- =========================================================================
 
 function addon:BuildActionRegistryFromDefinitions()
-    local registry = {}
-
-    local function StreamMatchesCapabilities(streamKey, requirement)
-        if type(requirement) ~= "table" then
-            return false
-        end
-        local caps = addon:GetStreamCapabilities(streamKey)
-        if type(caps) ~= "table" then
-            return false
-        end
-        for capKey, expected in pairs(requirement) do
-            if caps[capKey] ~= expected then
-                return false
-            end
-        end
-        return true
+    if not addon.TinyCoreRegistryCompiler or type(addon.TinyCoreRegistryCompiler.New) ~= "function" then
+        error("TinyCore RegistryCompiler is not initialized")
+    end
+    if not addon.TinyCoreRegistryActionPasses or type(addon.TinyCoreRegistryActionPasses.CreatePipeline) ~= "function" then
+        error("TinyCore Registry ActionPasses is not initialized")
     end
 
-    local function StreamMatchesScope(stream, appliesTo)
-        if type(stream) ~= "table" or type(appliesTo) ~= "table" then
-            return false
-        end
+    self._actionRegistryCompiler = self._actionRegistryCompiler or addon.TinyCoreRegistryCompiler:New({
+        passes = addon.TinyCoreRegistryActionPasses.CreatePipeline(),
+    })
 
-        if type(appliesTo.streamKind) == "string" and stream.kind ~= appliesTo.streamKind then
-            return false
-        end
-        if type(appliesTo.streamGroup) == "string" and stream.group ~= appliesTo.streamGroup then
-            return false
-        end
-        return true
-    end
-
-    local function RegisterActionForStream(actionDef, stream)
-        local fullKey = actionDef.key .. "_" .. stream.key
-        if registry[fullKey] then
-            return
-        end
-        local label = actionDef.getLabel and actionDef.getLabel(stream.key) or actionDef.label
-
-        if actionDef.category == "channel" and actionDef.key:match("send") then
-            label = L["ACTION_PREFIX_SEND"] .. (label or "")
-        end
-
-        registry[fullKey] = {
-            key = fullKey,
-            label = label,
-            tooltip = actionDef.getTooltip and actionDef.getTooltip(stream.key) or nil,
-            streamKey = stream.key,
-            category = actionDef.category,
-            actionPlane = actionDef.actionPlane or "UI_ONLY",
-            execute = function(...)
-                actionDef.execute(stream.key, ...)
-            end
-        }
-    end
-
-    local function BuildStreamKeySet(streamKeys)
-        if type(streamKeys) ~= "table" then
-            return nil
-        end
-        local set = {}
-        for _, key in ipairs(streamKeys) do
-            if type(key) == "string" and key ~= "" then
-                set[key] = true
-            end
-        end
-        return set
-    end
-
-    -- 遍历所有 ACTION 定义
-    for _, actionDef in ipairs(self.ACTION_DEFINITIONS or {}) do
-        if actionDef.appliesTo and not actionDef.appliesTo.kits then
-            local keySet = BuildStreamKeySet(actionDef.appliesTo.streamKeys)
-            for _, stream in self:IterateCompiledStreams() do
-                if (not keySet or keySet[stream.key] == true)
-                    and StreamMatchesScope(stream, actionDef.appliesTo)
-                    and (not actionDef.appliesTo.streamCapabilities
-                        or StreamMatchesCapabilities(stream.key, actionDef.appliesTo.streamCapabilities)) then
-                    RegisterActionForStream(actionDef, stream)
-                end
-            end
-        end
-
-        -- 如果 ACTION 声明了 kits
-        if actionDef.appliesTo and actionDef.appliesTo.kits then
-            for _, kitKey in ipairs(actionDef.appliesTo.kits) do
-                local fullKey = "kit_" .. kitKey .. "_" .. actionDef.key
-                local label = actionDef.getLabel and actionDef.getLabel(kitKey) or actionDef.label
-
-                -- 统一前缀处理：工具类
-                if actionDef.category == "kit" then
-                    label = L["ACTION_PREFIX_KIT"] .. (label or "")
-                end
-
-                registry[fullKey] = {
-                    key = fullKey,
-                    label = label,
-                    tooltip = actionDef.getTooltip and actionDef.getTooltip(kitKey) or nil,
-                    kitKey = kitKey,
-                    category = "kit",
-                    actionPlane = actionDef.actionPlane or "UI_ONLY",
-                    execute = actionDef.execute
-                }
-            end
-        end
-    end
-
-    return registry
+    return self._actionRegistryCompiler:Run(self.ACTION_DEFINITIONS or {}, {
+        iterateCompiledStreams = function()
+            return self:IterateCompiledStreams()
+        end,
+        getStreamCapabilities = function(streamKey)
+            return self:GetStreamCapabilities(streamKey)
+        end,
+        actionPrefixSend = L["ACTION_PREFIX_SEND"] or "",
+        actionPrefixKit = L["ACTION_PREFIX_KIT"] or "",
+    })
 end

--- a/Libs/TinyCore/RegistryCompiler/Compiler.lua
+++ b/Libs/TinyCore/RegistryCompiler/Compiler.lua
@@ -7,8 +7,8 @@ Compiler.__index = Compiler
 function Compiler:New(opts)
     local options = type(opts) == "table" and opts or {}
     local artifact = options.artifact
-    if type(artifact) ~= "table" or type(artifact.Freeze) ~= "function" then
-        error("TinyCore RegistryCompiler requires artifact with Freeze(value)")
+    if artifact ~= nil and (type(artifact) ~= "table" or type(artifact.Freeze) ~= "function") then
+        error("TinyCore RegistryCompiler artifact must expose Freeze(value)")
     end
 
     return setmetatable({
@@ -28,5 +28,8 @@ function Compiler:Run(input, context)
         state = pass(state, ctx)
     end
 
-    return self.artifact:Freeze(state)
+    if self.artifact then
+        return self.artifact:Freeze(state)
+    end
+    return state
 end

--- a/Libs/TinyCore/RegistryCompiler/Passes/ActionPasses.lua
+++ b/Libs/TinyCore/RegistryCompiler/Passes/ActionPasses.lua
@@ -1,0 +1,135 @@
+local addonName, addon = ...
+
+addon.TinyCoreRegistryActionPasses = addon.TinyCoreRegistryActionPasses or {}
+local Passes = addon.TinyCoreRegistryActionPasses
+
+local function BuildStreamKeySet(streamKeys)
+    if type(streamKeys) ~= "table" then
+        return nil
+    end
+    local set = {}
+    for _, key in ipairs(streamKeys) do
+        if type(key) == "string" and key ~= "" then
+            set[key] = true
+        end
+    end
+    return set
+end
+
+local function StreamMatchesCapabilities(streamKey, requirement, getStreamCapabilities)
+    if type(requirement) ~= "table" then
+        return false
+    end
+    local caps = getStreamCapabilities(streamKey)
+    if type(caps) ~= "table" then
+        return false
+    end
+    for capKey, expected in pairs(requirement) do
+        if caps[capKey] ~= expected then
+            return false
+        end
+    end
+    return true
+end
+
+local function StreamMatchesScope(stream, appliesTo)
+    if type(stream) ~= "table" or type(appliesTo) ~= "table" then
+        return false
+    end
+
+    if type(appliesTo.streamKind) == "string" and stream.kind ~= appliesTo.streamKind then
+        return false
+    end
+    if type(appliesTo.streamGroup) == "string" and stream.group ~= appliesTo.streamGroup then
+        return false
+    end
+    return true
+end
+
+function Passes.BuildRegistry(actionDefinitions, ctx)
+    local context = type(ctx) == "table" and ctx or {}
+    local iterateCompiledStreams = context.iterateCompiledStreams
+    local getStreamCapabilities = context.getStreamCapabilities
+    local actionPrefixSend = context.actionPrefixSend or ""
+    local actionPrefixKit = context.actionPrefixKit or ""
+
+    if type(iterateCompiledStreams) ~= "function" then
+        error("ActionPasses requires iterateCompiledStreams()")
+    end
+    if type(getStreamCapabilities) ~= "function" then
+        error("ActionPasses requires getStreamCapabilities(streamKey)")
+    end
+
+    local registry = {}
+    local definitions = type(actionDefinitions) == "table" and actionDefinitions or {}
+
+    local function RegisterActionForStream(actionDef, stream)
+        local fullKey = actionDef.key .. "_" .. stream.key
+        if registry[fullKey] then
+            return
+        end
+
+        local label = actionDef.getLabel and actionDef.getLabel(stream.key) or actionDef.label
+        if actionDef.category == "channel" and type(actionDef.key) == "string" and actionDef.key:match("send") then
+            label = actionPrefixSend .. (label or "")
+        end
+
+        registry[fullKey] = {
+            key = fullKey,
+            label = label,
+            tooltip = actionDef.getTooltip and actionDef.getTooltip(stream.key) or nil,
+            streamKey = stream.key,
+            category = actionDef.category,
+            actionPlane = actionDef.actionPlane or "UI_ONLY",
+            execute = function(...)
+                actionDef.execute(stream.key, ...)
+            end,
+        }
+    end
+
+    for _, actionDef in ipairs(definitions) do
+        if type(actionDef) == "table" and type(actionDef.key) == "string" and actionDef.key ~= "" then
+            if actionDef.appliesTo and not actionDef.appliesTo.kits then
+                local keySet = BuildStreamKeySet(actionDef.appliesTo.streamKeys)
+                for _, stream in iterateCompiledStreams() do
+                    if (not keySet or keySet[stream.key] == true)
+                        and StreamMatchesScope(stream, actionDef.appliesTo)
+                        and (not actionDef.appliesTo.streamCapabilities
+                            or StreamMatchesCapabilities(stream.key, actionDef.appliesTo.streamCapabilities, getStreamCapabilities)) then
+                        RegisterActionForStream(actionDef, stream)
+                    end
+                end
+            end
+
+            if actionDef.appliesTo and actionDef.appliesTo.kits then
+                for _, kitKey in ipairs(actionDef.appliesTo.kits) do
+                    local fullKey = "kit_" .. kitKey .. "_" .. actionDef.key
+                    local label = actionDef.getLabel and actionDef.getLabel(kitKey) or actionDef.label
+                    if actionDef.category == "kit" then
+                        label = actionPrefixKit .. (label or "")
+                    end
+
+                    registry[fullKey] = {
+                        key = fullKey,
+                        label = label,
+                        tooltip = actionDef.getTooltip and actionDef.getTooltip(kitKey) or nil,
+                        kitKey = kitKey,
+                        category = "kit",
+                        actionPlane = actionDef.actionPlane or "UI_ONLY",
+                        execute = actionDef.execute,
+                    }
+                end
+            end
+        end
+    end
+
+    return registry
+end
+
+function Passes.CreatePipeline()
+    return {
+        function(actionDefinitions, ctx)
+            return Passes.BuildRegistry(actionDefinitions, ctx)
+        end,
+    }
+end

--- a/TinyChaton.toc
+++ b/TinyChaton.toc
@@ -36,6 +36,7 @@ Libs\TinyCore\RuntimeGovernor\Reconciler.lua
 Libs\TinyCore\RegistryCompiler\Artifact.lua
 Libs\TinyCore\RegistryCompiler\Compiler.lua
 Libs\TinyCore\RegistryCompiler\Passes\StreamPasses.lua
+Libs\TinyCore\RegistryCompiler\Passes\ActionPasses.lua
 Libs\TinyCore\SettingsSchema\SchemaRegistry.lua
 Libs\TinyCore\SettingsSchema\Validator.lua
 Libs\TinyCore\SettingsSchema\ControlModel.lua


### PR DESCRIPTION
## Summary
- add action registry compiler pass: `Libs/TinyCore/RegistryCompiler/Passes/ActionPasses.lua`
- update TinyCore compiler to support optional artifact freezing (stream compiler still freezes; action compiler keeps mutable output)
- refactor `Domain/Stream/Actions/StreamActionRegistry.lua` into a thin adapter delegating to TinyCore action pass compiler
- update `TinyChaton.toc` load order to include action passes before domain consumers

## Compatibility
- external API unchanged: `addon:BuildActionRegistryFromDefinitions()` still returns same action table shape
- action definition semantics preserved (stream scope/capability filters, kit action expansion, send/kit label prefix rules)

## Verification
- `luac -p` passed for touched files
