### PR TITLE
docs: align architecture docs with action compiler migration

### DIFF
--- a/Docs/0008-SPEC-architecture-overview.md
+++ b/Docs/0008-SPEC-architecture-overview.md
@@ -30,7 +30,7 @@ status: ACTIVE
 
 3. Stream Domain（通用）
 - Registry: `StreamRegistry`
-- Actions: `StreamActionRegistry`
+- Actions: `StreamActionRegistry`（委托 TinyCore ActionPasses compiler）
 - Context: `StreamEventContext`
 - Ingress: `StreamEventDispatcher`
 - Rules: `StreamRuleEngine`（委托 TinyCore RuleEngine）
@@ -63,6 +63,7 @@ status: ACTIVE
 1. `STEP 01-06` 已全部完成并合并（见 `#0024-#0029`）。
 2. 分支与 Libs 落位基线已执行（见 `#0030`）。
 3. 当前结构为 `TinyCore 内核 + Domain/Infrastructure 适配` 的稳定态。
+4. RegistryCompiler 已覆盖 stream + action 两类声明式编译路径。
 
 ## 关键验收
 

--- a/Docs/0028-PLAN-step-05-registry-compiler-core.md
+++ b/Docs/0028-PLAN-step-05-registry-compiler-core.md
@@ -50,6 +50,12 @@ status: RESOLVED
 2. `Libs/TinyCore/RegistryCompiler/Passes/*`
 3. `Libs/TinyCore/RegistryCompiler/Artifact.lua`
 
+## 落地结果（补充）
+
+1. stream 编译 pass 已落地：`Passes/StreamPasses.lua`。
+2. action 编译 pass 已落地：`Passes/ActionPasses.lua`。
+3. `Domain/Stream/Actions/StreamActionRegistry.lua` 已切换为 TinyCore compiler 薄适配。
+
 ## 执行步骤
 
 1. 抽离 pass 接口与执行器。


### PR DESCRIPTION
## Summary
- update Docs/0028 with post-implementation result notes for stream and action compiler passes
- update Docs/0008 to reflect that StreamActionRegistry now delegates to TinyCore action compiler passes

## Scope
- docs-only change
